### PR TITLE
feat(refactor): new api for koex cache

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -21,124 +21,238 @@ const createApp = (options?: Options) => {
   return _app;
 };
 
-const cache = new LRU<string, any>(100);
-const app = createApp({
-  key: ctx => ctx.url,
-  max: 10,
-  db: {
-    get: cache.get.bind(cache),
-    set: cache.set.bind(cache),
-    hits: cache.hits.bind(cache),
-    hasKey: cache.hasKey.bind(cache),
-  },
-});
-
 describe('Cache Hits', () => {
-  it('no cache, hit nothing (0/1)', (done) => {
-    request(app.callback())
-      .get('/')
-      .expect(200)
-      .expect('hello, world', (err, res) => {
-        if (err) return done(err);
+  describe('with internal lru cache', () => {
+    const app = createApp({
+      key: ctx => ctx.url,
+      max: 10,
+    });
 
-        expect(res.headers['X-Cache-Hits']).toEqual(undefined);
-        done();
-      });
+    it('no cache, hit nothing (0/1)', (done) => {
+      request(app.callback())
+        .get('/')
+        .expect(200)
+        .expect('hello, world', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['X-Cache-Hits']).toEqual(undefined);
+          done();
+        });
+    });
+  
+    it('hit cache (1/2)', (done) => {
+      request(app.callback())
+        .get('/')
+        .expect(200)
+        .expect('hello, world', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual('rate=50.00%');
+          done();
+        });
+    });
+  
+    it('first vist json, miss hit (1/3)', (done) => {
+      request(app.callback())
+        .get('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+
+          expect(res.headers['X-Cache-Hits']).toEqual(undefined);
+          done();
+        });
+    });
+
+    it('hit cache (2/4)', (done) => {
+      request(app.callback())
+        .get('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual('rate=50.00%');
+          done();
+        });
+    });
+  
+    it('hit cache (3/5)', (done) => {
+      request(app.callback())
+        .get('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual('rate=60.00%');
+          done();
+        });
+    });
+  
+    it('hit cache (4/6)', (done) => {
+      request(app.callback())
+        .get('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual('rate=66.67%');
+          done();
+        });
+    });
+  
+    it('only cache GET (post)', (done) => {
+      request(app.callback())
+        .post('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual(undefined);
+          done();
+        });
+    });
+  
+    it('only cache GET (patch)', (done) => {
+      request(app.callback())
+        .patch('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual(undefined);
+          done();
+        });
+    });
+  
+    it('only cache GET (delete)', (done) => {
+      request(app.callback())
+        .delete('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual(undefined);
+          done();
+        });
+    });
   });
 
-  it('hit cache (1/2)', (done) => {
-    request(app.callback())
-      .get('/')
-      .expect(200)
-      .expect('hello, world', (err, res) => {
-        if (err) return done(err);
+  describe('with custom cache', () => {
+    const cache = new LRU<string, any>(100);
+    const app = createApp({
+      key: ctx => ctx.url,
+      max: 10,
+      get: cache.get.bind(cache),
+      set: cache.set.bind(cache),
+      hits: cache.hits.bind(cache),
+    });
 
-        expect(res.headers['x-cache-hits']).toEqual('rate=50.00%');
-        done();
-      });
-  });
-
-  it('first vist json, miss hit (1/3)', (done) => {
-    request(app.callback())
-      .get('/json')
-      .expect(200)
-      .expect('{"name":"name","value":"value"}', (err, res) => {
-        if (err) return done(err);
-
-        expect(res.headers['X-Cache-Hits']).toEqual(undefined);
-        done();
-      });
-  });
-
-  it('hit cache (2/4)', (done) => {
-    request(app.callback())
-      .get('/json')
-      .expect(200)
-      .expect('{"name":"name","value":"value"}', (err, res) => {
-        if (err) return done(err);
-
-        expect(res.headers['x-cache-hits']).toEqual('rate=50.00%');
-        done();
-      });
-  });
-
-  it('hit cache (3/5)', (done) => {
-    request(app.callback())
-      .get('/json')
-      .expect(200)
-      .expect('{"name":"name","value":"value"}', (err, res) => {
-        if (err) return done(err);
-
-        expect(res.headers['x-cache-hits']).toEqual('rate=60.00%');
-        done();
-      });
-  });
-
-  it('hit cache (4/6)', (done) => {
-    request(app.callback())
-      .get('/json')
-      .expect(200)
-      .expect('{"name":"name","value":"value"}', (err, res) => {
-        if (err) return done(err);
-
-        expect(res.headers['x-cache-hits']).toEqual('rate=66.67%');
-        done();
-      });
-  });
-
-  it('only cache GET (post)', (done) => {
-    request(app.callback())
-      .post('/json')
-      .expect(200)
-      .expect('{"name":"name","value":"value"}', (err, res) => {
-        if (err) return done(err);
-
-        expect(res.headers['x-cache-hits']).toEqual(undefined);
-        done();
-      });
-  });
-
-  it('only cache GET (patch)', (done) => {
-    request(app.callback())
-      .patch('/json')
-      .expect(200)
-      .expect('{"name":"name","value":"value"}', (err, res) => {
-        if (err) return done(err);
-
-        expect(res.headers['x-cache-hits']).toEqual(undefined);
-        done();
-      });
-  });
-
-  it('only cache GET (delete)', (done) => {
-    request(app.callback())
-      .delete('/json')
-      .expect(200)
-      .expect('{"name":"name","value":"value"}', (err, res) => {
-        if (err) return done(err);
-
-        expect(res.headers['x-cache-hits']).toEqual(undefined);
-        done();
-      });
+    it('no cache, hit nothing (0/1)', (done) => {
+      request(app.callback())
+        .get('/')
+        .expect(200)
+        .expect('hello, world', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['X-Cache-Hits']).toEqual(undefined);
+          done();
+        });
+    });
+  
+    it('hit cache (1/2)', (done) => {
+      request(app.callback())
+        .get('/')
+        .expect(200)
+        .expect('hello, world', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual('rate=50.00%');
+          done();
+        });
+    });
+  
+    it('first vist json, miss hit (1/3)', (done) => {
+      request(app.callback())
+        .get('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['X-Cache-Hits']).toEqual(undefined);
+          done();
+        });
+    });
+  
+    it('hit cache (2/4)', (done) => {
+      request(app.callback())
+        .get('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual('rate=50.00%');
+          done();
+        });
+    });
+  
+    it('hit cache (3/5)', (done) => {
+      request(app.callback())
+        .get('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual('rate=60.00%');
+          done();
+        });
+    });
+  
+    it('hit cache (4/6)', (done) => {
+      request(app.callback())
+        .get('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual('rate=66.67%');
+          done();
+        });
+    });
+  
+    it('only cache GET (post)', (done) => {
+      request(app.callback())
+        .post('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual(undefined);
+          done();
+        });
+    });
+  
+    it('only cache GET (patch)', (done) => {
+      request(app.callback())
+        .patch('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual(undefined);
+          done();
+        });
+    });
+  
+    it('only cache GET (delete)', (done) => {
+      request(app.callback())
+        .delete('/json')
+        .expect(200)
+        .expect('{"name":"name","value":"value"}', (err, res) => {
+          if (err) return done(err);
+  
+          expect(res.headers['x-cache-hits']).toEqual(undefined);
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
```
export interface Options {
  /**
   * A hash key function. default: (ctx: Context) => ctx.url.
   */
  key?: keyof Context & string | ((ctx: Context) => string);

  /**
   * Max db cache size for LRU. If use self db instance, it will be ignored.
   */
  max?: number;

  /**
   * Cache max age. default: 3600 (s);
   */
  maxAge?: number;

  /**
   * Get a value from store by key.
   *
   * @param key cache key
   * @param maxAge cache max age
   * @returns Promise<Cached>
   */
  get?(key: string, maxAge: number): Promise<Cached | undefined>;

  /**
   * Set a value to store.
   *
   * @param key cache key
   * @param value cache value
   * @param maxAge cache max age
   */
  set?(key: string, value: Cached, maxAge: number): Promise<void>

  /**
   * Hit cache key with { count, rate }
   *
   * @param key cache key
   */
  hits?(key: string): Hits | Promise<Hits>;
}
```